### PR TITLE
Add FluxGym LoRA training blog post

### DIFF
--- a/src/content/posts/2024-06-10-flux-test.md
+++ b/src/content/posts/2024-06-10-flux-test.md
@@ -1,0 +1,69 @@
+---
+template: blog-post
+title: "Flux test"
+slug: /flux-test
+date: 2024-06-10 12:00
+description: Training a LoRA on my own photos using FluxGym
+featuredImage: /assets/comfyui_00035_.png
+---
+<!DOCTYPE html>
+
+<html>
+<head>
+        <title>Table of Contents</title>
+</head>
+<body>
+        <h1>Table of Contents</h1>
+        <ol>
+                <!-- Link to section 1: Getting started -->
+                <li><a href="#section1">Getting started</a></li>
+                <!-- Link to section 2: Preparing the dataset -->
+                <li><a href="#section2">Preparing the dataset</a></li>
+                <!-- Link to section 3: Training the LoRA -->
+                <li><a href="#section3">Training the LoRA</a></li>
+                <!-- Link to section 4: Results -->
+                <li><a href="#section4">Results</a></li>
+        </ol>
+
+<!--StartFragment-->
+
+<!-- Section 1: Getting started -->
+
+<h2 id="section1">Getting started</h2>
+
+<p>
+I’d been experimenting with image generation for a while when I heard about FluxGym’s easy–to–use training interface. The promise of a smooth workflow for LoRA models was too tempting to ignore. After signing up I installed the FluxGym client on my machine and explored the dashboard to get a feel for the process.
+</p>
+
+<!--StartFragment-->
+
+<!-- Section 2: Preparing the dataset -->
+
+<h2 id="section2">Preparing the dataset</h2>
+
+<p>
+To train a personal LoRA I gathered a small set of selfies taken under different lighting conditions. I cropped the images so my face was centred and ensured each file was at least 512x512 pixels. FluxGym made it straightforward to upload everything in one batch and organise it into a new project.
+</p>
+
+<!--StartFragment-->
+
+<!-- Section 3: Training the LoRA -->
+
+<h2 id="section3">Training the LoRA</h2>
+
+<p>
+With the dataset ready I tweaked the hyperparameters suggested by FluxGym’s presets. I opted for a lower learning rate to preserve the original style of the base model. Training kicked off in the cloud and within an hour I could see the LoRA gradually learning my features.
+</p>
+
+<!--StartFragment-->
+
+<!-- Section 4: Results -->
+
+<h2 id="section4">Results</h2>
+
+<p>
+The final model produced surprisingly consistent portraits. FluxGym’s training logs helped me identify the best checkpoint, and I downloaded the LoRA to use in ComfyUI. Now I can generate stylised images of myself with a single prompt—perfect for experimenting with new artistic directions.
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create blog post `Flux test` with details about using FluxGym for training a LoRA on personal images

## Testing
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684445c40210832f9b689ae7e74ab325