### PR TITLE
Improve image quality handling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,7 +30,15 @@ module.exports = {
       },
     },
     `gatsby-plugin-image`,
-    `gatsby-plugin-sharp`,
+    {
+      resolve: `gatsby-plugin-sharp`,
+      options: {
+        defaults: {
+          quality: 100,
+        },
+        defaultQuality: 100,
+      },
+    },
     `gatsby-transformer-sharp`,
     {
       resolve: `gatsby-transformer-remark`,
@@ -46,6 +54,7 @@ module.exports = {
               linkImagesToOriginal: false,
               tracedSVG: true,
               loading: "lazy",
+              quality: 100,
             },
           },
           {

--- a/src/templates/blog-list.js
+++ b/src/templates/blog-list.js
@@ -39,7 +39,12 @@ export const blogListQuery = graphql`
             title
             featuredImage {
               childImageSharp {
-                gatsbyImageData(layout: CONSTRAINED, width: 345, height: 260)
+                gatsbyImageData(
+                  layout: CONSTRAINED
+                  width: 345
+                  height: 260
+                  quality: 100
+                )
               }
             }
           }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -27,25 +27,26 @@ const styles = {
 const Pagination = props => (
   <div className="pagination -post" sx={styles.pagination}>
     <ul>
-      {props.previous && props.previous.frontmatter.template === "blog-post" && (
-        <li>
-          <Link to={props.previous.frontmatter.slug} rel="prev">
-            <p
-              sx={{
-                color: "muted",
-              }}
-            >
-              <span className="icon -left">
-                <RiArrowLeftLine />
-              </span>{" "}
-              Previous
-            </p>
-            <span className="page-title">
-              {props.previous.frontmatter.title}
-            </span>
-          </Link>
-        </li>
-      )}
+      {props.previous &&
+        props.previous.frontmatter.template === "blog-post" && (
+          <li>
+            <Link to={props.previous.frontmatter.slug} rel="prev">
+              <p
+                sx={{
+                  color: "muted",
+                }}
+              >
+                <span className="icon -left">
+                  <RiArrowLeftLine />
+                </span>{" "}
+                Previous
+              </p>
+              <span className="page-title">
+                {props.previous.frontmatter.title}
+              </span>
+            </Link>
+          </li>
+        )}
       {props.next && props.next.frontmatter.template === "blog-post" && (
         <li>
           <Link to={props.next.frontmatter.slug} rel="next">
@@ -95,7 +96,7 @@ const Post = ({ data, pageContext }) => {
         <header className="featured-banner">
           <section className="article-header">
             <h1>{frontmatter.title}</h1>
-            <time sx={{color: "muted"}}>{frontmatter.date}</time>
+            <time sx={{ color: "muted" }}>{frontmatter.date}</time>
           </section>
           {Image ? (
             <GatsbyImage
@@ -133,7 +134,7 @@ export const pageQuery = graphql`
         description
         featuredImage {
           childImageSharp {
-            gatsbyImageData(layout: FULL_WIDTH)
+            gatsbyImageData(layout: FULL_WIDTH, quality: 100)
           }
         }
       }

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -39,7 +39,12 @@ export const pageQuery = graphql`
         tagline
         featuredImage {
           childImageSharp {
-            gatsbyImageData(layout: CONSTRAINED, width: 585, height: 439)
+            gatsbyImageData(
+              layout: CONSTRAINED
+              width: 585
+              height: 439
+              quality: 100
+            )
           }
         }
         cta {
@@ -63,7 +68,12 @@ export const pageQuery = graphql`
             title
             featuredImage {
               childImageSharp {
-                gatsbyImageData(layout: CONSTRAINED, width: 345, height: 260)
+                gatsbyImageData(
+                  layout: CONSTRAINED
+                  width: 345
+                  height: 260
+                  quality: 100
+                )
               }
             }
           }
@@ -103,7 +113,7 @@ const HomePage = ({ data }) => {
         ) : (
           ""
         )}
-         {icons.icon === "python" ? (
+        {icons.icon === "python" ? (
           <Link to={icons.url} target="_blank">
             <DiPython />
           </Link>


### PR DESCRIPTION
## Summary
- raise default image quality in `gatsby-config.js`
- bump remark image quality setting
- request high-quality images in blog queries

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_68451c7c7ec4832f862d603801906b1c